### PR TITLE
Refactor resources, use tick less frequently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [[v0.0.2]](https://github.com/mlange-42/arche/compare/v0.0.1...v0.0.2)
+## [[v0.0.2]](https://github.com/mlange-42/arche-model/compare/v0.0.1...v0.0.2)
 
 ### Breaking changes
 
@@ -15,13 +15,14 @@
 
 * Fix check when removing a system that is not in `Systems` (#15)
 
-### Other
-
-* Systems are removed immediately when `Systems.RemoveSystem` is called outside of a loop over systems (#15)
-* Included systems do no longer depend on resource `Tick` (formerly `Time`) (#16)
-
 ### Documentation
 
 * Improves examples with inline comments (#9)
 * Adds a CHANGELOG.md file (#9)
 * Adds examples for implementing `System` and `UISystem` (#10)
+
+### Other
+
+* Systems are removed immediately when `Systems.RemoveSystem` is called outside of a loop over systems (#15)
+* Included systems do no longer depend on resource `Tick` (formerly `Time`) (#16)
+* Upgrade to dependency to Arche v0.6.1 (#16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [[v0.0.2]](https://github.com/mlange-42/arche/compare/v0.0.1...v0.0.2)
 
+### Breaking changes
+
+* Resource `Time` is now split into `Tick` and `Termination` (#16)
+
 ### Features
 
 * Adds a system `CallbackTermination` to end the simulation based on a callback (#13)
@@ -13,6 +17,7 @@
 ### Other
 
 * Systems are removed immediately when `Systems.RemoveSystem` is called outside of a loop over systems (#15)
+* Included systems do no longer depend on resource `Tick` (formerly `Time`) (#16)
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking changes
 
+* All resources moved to package `resource` (#16)
 * Resource `Time` is now split into `Tick` and `Termination` (#16)
 
 ### Features

--- a/doc.go
+++ b/doc.go
@@ -5,4 +5,5 @@
 //   - Arche wrapper & scheduler -- [github.com/mlange-42/arche-model/model]
 //   - General-purpose systems -- [github.com/mlange-42/arche-model/system]
 //   - Reporter systems -- [github.com/mlange-42/arche-model/reporter]
+//   - Commonly used resources -- [github.com/mlange-42/arche-model/resource]
 package archemodel

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/mlange-42/arche-model
 go 1.20
 
 require (
-	github.com/mlange-42/arche v0.6.0
+	github.com/mlange-42/arche v0.6.1
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb
 )

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/mlange-42/arche v0.6.0 h1:xF/jlJeSjX1Yt7JdiGcPIS0q20ATqwbegU5cIP0/j4g=
 github.com/mlange-42/arche v0.6.0/go.mod h1:cgOiMHWCbNAb5L5mCihS2yzdk1Zll1IoBJL+3wVm0AM=
+github.com/mlange-42/arche v0.6.1 h1:MA0VTHvlGxw44MRfj8qbHLnB5QQFAXueGYRiQgLGPVc=
+github.com/mlange-42/arche v0.6.1/go.mod h1:cgOiMHWCbNAb5L5mCihS2yzdk1Zll1IoBJL+3wVm0AM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/model/example_system_test.go
+++ b/model/example_system_test.go
@@ -11,12 +11,12 @@ import (
 
 // TestSystem is an example for implementing [System].
 type TestSystem struct {
-	timeRes generic.Resource[model.Time]
+	timeRes generic.Resource[model.Tick]
 }
 
 // Initialize the system.
 func (s *TestSystem) Initialize(w *ecs.World) {
-	s.timeRes = generic.NewResource[model.Time](w)
+	s.timeRes = generic.NewResource[model.Tick](w)
 }
 
 // Update the system.

--- a/model/example_system_test.go
+++ b/model/example_system_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/mlange-42/arche-model/model"
+	"github.com/mlange-42/arche-model/resource"
 	"github.com/mlange-42/arche-model/system"
 	"github.com/mlange-42/arche/ecs"
 	"github.com/mlange-42/arche/generic"
@@ -11,12 +12,12 @@ import (
 
 // TestSystem is an example for implementing [System].
 type TestSystem struct {
-	timeRes generic.Resource[model.Tick]
+	timeRes generic.Resource[resource.Tick]
 }
 
 // Initialize the system.
 func (s *TestSystem) Initialize(w *ecs.World) {
-	s.timeRes = generic.NewResource[model.Tick](w)
+	s.timeRes = generic.NewResource[resource.Tick](w)
 }
 
 // Update the system.

--- a/model/example_ui_system_test.go
+++ b/model/example_ui_system_test.go
@@ -11,12 +11,12 @@ import (
 
 // TestUISystem is an example for implementing [UISystem].
 type TestUISystem struct {
-	timeRes generic.Resource[model.Time]
+	timeRes generic.Resource[model.Tick]
 }
 
 // Initialize the system.
 func (s *TestUISystem) InitializeUI(w *ecs.World) {
-	s.timeRes = generic.NewResource[model.Time](w)
+	s.timeRes = generic.NewResource[model.Tick](w)
 }
 
 // Update the system.

--- a/model/example_ui_system_test.go
+++ b/model/example_ui_system_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/mlange-42/arche-model/model"
+	"github.com/mlange-42/arche-model/resource"
 	"github.com/mlange-42/arche-model/system"
 	"github.com/mlange-42/arche/ecs"
 	"github.com/mlange-42/arche/generic"
@@ -11,12 +12,12 @@ import (
 
 // TestUISystem is an example for implementing [UISystem].
 type TestUISystem struct {
-	timeRes generic.Resource[model.Tick]
+	timeRes generic.Resource[resource.Tick]
 }
 
 // Initialize the system.
 func (s *TestUISystem) InitializeUI(w *ecs.World) {
-	s.timeRes = generic.NewResource[model.Tick](w)
+	s.timeRes = generic.NewResource[resource.Tick](w)
 }
 
 // Update the system.

--- a/model/model.go
+++ b/model/model.go
@@ -3,6 +3,7 @@ package model
 import (
 	"time"
 
+	"github.com/mlange-42/arche-model/resource"
 	"github.com/mlange-42/arche/ecs"
 	"golang.org/x/exp/rand"
 )
@@ -14,9 +15,9 @@ import (
 type Model struct {
 	Systems             // Systems manager and scheduler
 	World     ecs.World // The ECS world
-	rand      Rand
-	time      Tick
-	terminate Termination
+	rand      resource.Rand
+	time      resource.Tick
+	terminate resource.Termination
 }
 
 // New creates a new model.
@@ -28,11 +29,13 @@ func New(config ...ecs.Config) *Model {
 	mod.Tps = 0
 	mod.Systems.world = &mod.World
 
-	mod.rand = Rand{rand.NewSource(uint64(time.Now().UnixNano()))}
+	mod.rand = resource.Rand{
+		Source: rand.NewSource(uint64(time.Now().UnixNano())),
+	}
 	ecs.AddResource(&mod.World, &mod.rand)
-	mod.time = Tick{}
+	mod.time = resource.Tick{}
 	ecs.AddResource(&mod.World, &mod.time)
-	mod.terminate = Termination{}
+	mod.terminate = resource.Termination{}
 	ecs.AddResource(&mod.World, &mod.terminate)
 
 	ecs.AddResource(&mod.World, &mod.Systems)
@@ -65,11 +68,13 @@ func (m *Model) Reset() {
 	m.World.Reset()
 	m.Systems.reset()
 
-	m.rand = Rand{rand.NewSource(uint64(time.Now().UnixNano()))}
+	m.rand = resource.Rand{
+		Source: rand.NewSource(uint64(time.Now().UnixNano())),
+	}
 	ecs.AddResource(&m.World, &m.rand)
-	m.time = Tick{}
+	m.time = resource.Tick{}
 	ecs.AddResource(&m.World, &m.time)
-	m.terminate = Termination{}
+	m.terminate = resource.Termination{}
 	ecs.AddResource(&m.World, &m.terminate)
 
 	ecs.AddResource(&m.World, &m.Systems)

--- a/model/resources.go
+++ b/model/resources.go
@@ -7,8 +7,12 @@ type Rand struct {
 	rand.Source // Source to use for PRNGs in [System] implementations.
 }
 
-// Time is a resource holding the model's time step.
-type Time struct {
-	Tick     int64 // The current model tick.
-	Finished bool  // Whether the model run is finished. Can be set by systems.
+// Tick is a resource holding the model's time step.
+type Tick struct {
+	Tick int64 // The current model tick.
+}
+
+// Termination is a resource holding a whether ths system should terminate after the current step.
+type Termination struct {
+	Terminate bool // Whether the model run is finished. Can be set by systems.
 }

--- a/model/resources_test.go
+++ b/model/resources_test.go
@@ -17,11 +17,20 @@ func ExampleRand() {
 	// Output:
 }
 
-func ExampleTime() {
+func ExampleTick() {
 	m := model.New()
 
-	time := ecs.GetResource[model.Time](&m.World)
+	tick := ecs.GetResource[model.Tick](&m.World)
 
-	fmt.Println(time.Tick)
+	fmt.Println(tick.Tick)
 	// Output: 0
+}
+
+func ExampleTermination() {
+	m := model.New()
+
+	term := ecs.GetResource[model.Termination](&m.World)
+
+	fmt.Println(term.Terminate)
+	// Output: false
 }

--- a/model/systems.go
+++ b/model/systems.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/mlange-42/arche-model/resource"
 	"github.com/mlange-42/arche/ecs"
 	"github.com/mlange-42/arche/generic"
 )
@@ -40,8 +41,8 @@ type Systems struct {
 	initialized bool
 	locked      bool
 
-	tickRes generic.Resource[Tick]
-	termRes generic.Resource[Termination]
+	tickRes generic.Resource[resource.Tick]
+	termRes generic.Resource[resource.Termination]
 }
 
 // AddSystem adds a [System] to the model.
@@ -129,8 +130,8 @@ func (s *Systems) removeSystems() {
 
 // Initialize all systems.
 func (s *Systems) initialize() {
-	s.tickRes = generic.NewResource[Tick](s.world)
-	s.termRes = generic.NewResource[Termination](s.world)
+	s.tickRes = generic.NewResource[resource.Tick](s.world)
+	s.termRes = generic.NewResource[resource.Termination](s.world)
 
 	if s.initialized {
 		panic("model is already initialized")
@@ -274,5 +275,5 @@ func (s *Systems) reset() {
 	s.lastUpdate = time.Time{}
 
 	s.initialized = false
-	s.tickRes = generic.Resource[Tick]{}
+	s.tickRes = generic.Resource[resource.Tick]{}
 }

--- a/model/systems.go
+++ b/model/systems.go
@@ -40,7 +40,8 @@ type Systems struct {
 	initialized bool
 	locked      bool
 
-	timeRes generic.Resource[Time]
+	tickRes generic.Resource[Tick]
+	termRes generic.Resource[Termination]
 }
 
 // AddSystem adds a [System] to the model.
@@ -128,7 +129,8 @@ func (s *Systems) removeSystems() {
 
 // Initialize all systems.
 func (s *Systems) initialize() {
-	s.timeRes = generic.NewResource[Time](s.world)
+	s.tickRes = generic.NewResource[Tick](s.world)
+	s.termRes = generic.NewResource[Termination](s.world)
 
 	if s.initialized {
 		panic("model is already initialized")
@@ -155,7 +157,7 @@ func (s *Systems) update() {
 	s.removeSystems()
 
 	if update {
-		time := s.timeRes.Get()
+		time := s.tickRes.Get()
 		time.Tick++
 	} else {
 		s.wait()
@@ -250,10 +252,11 @@ func (s *Systems) run() {
 		s.initialize()
 	}
 
-	time := s.timeRes.Get()
+	time := s.tickRes.Get()
 	time.Tick = 0
+	terminate := s.termRes.Get()
 
-	for !time.Finished {
+	for !terminate.Terminate {
 		s.update()
 	}
 
@@ -271,5 +274,5 @@ func (s *Systems) reset() {
 	s.lastUpdate = time.Time{}
 
 	s.initialized = false
-	s.timeRes = generic.Resource[Time]{}
+	s.tickRes = generic.Resource[Tick]{}
 }

--- a/reporter/csv_snaphot.go
+++ b/reporter/csv_snaphot.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/mlange-42/arche-model/model"
 	"github.com/mlange-42/arche/ecs"
-	"github.com/mlange-42/arche/generic"
 )
 
 // SnapshotCSV reporter.
@@ -21,7 +20,7 @@ type SnapshotCSV struct {
 	UpdateInterval int                  // Update interval in model ticks.
 	header         []string
 	builder        strings.Builder
-	timeRes        generic.Resource[model.Time]
+	step           int64
 }
 
 // Initialize the system
@@ -38,16 +37,14 @@ func (s *SnapshotCSV) Initialize(w *ecs.World) {
 		panic(err)
 	}
 
-	s.timeRes = generic.NewResource[model.Time](w)
+	s.step = 0
 }
 
 // Update the system
 func (s *SnapshotCSV) Update(w *ecs.World) {
-	time := s.timeRes.Get()
-
 	s.Observer.Update(w)
-	if s.UpdateInterval == 0 || time.Tick%int64(s.UpdateInterval) == 0 {
-		file, err := os.Create(fmt.Sprintf(s.FilePattern, time.Tick))
+	if s.UpdateInterval == 0 || s.step%int64(s.UpdateInterval) == 0 {
+		file, err := os.Create(fmt.Sprintf(s.FilePattern, s.step))
 		if err != nil {
 			panic(err)
 		}
@@ -79,6 +76,7 @@ func (s *SnapshotCSV) Update(w *ecs.World) {
 			panic(err)
 		}
 	}
+	s.step++
 }
 
 // Finalize the system

--- a/reporter/print.go
+++ b/reporter/print.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/mlange-42/arche-model/model"
 	"github.com/mlange-42/arche/ecs"
-	"github.com/mlange-42/arche/generic"
 )
 
 // Print reporter to print a table row per time step.
@@ -13,26 +12,24 @@ type Print struct {
 	Observer       model.Observer // Observer to get data from.
 	UpdateInterval int            // Update/print interval in model ticks.
 	header         []string
-	timeRes        generic.Resource[model.Time]
+	step           int64
 }
 
 // Initialize the system
 func (s *Print) Initialize(w *ecs.World) {
 	s.Observer.Initialize(w)
 	s.header = s.Observer.Header(w)
-
-	s.timeRes = generic.NewResource[model.Time](w)
+	s.step = 0
 }
 
 // Update the system
 func (s *Print) Update(w *ecs.World) {
-	time := s.timeRes.Get()
-
 	s.Observer.Update(w)
-	if time.Tick%int64(s.UpdateInterval) == 0 {
+	if s.step%int64(s.UpdateInterval) == 0 {
 		values := s.Observer.Values(w)
 		fmt.Printf("%v\n%v\n", s.header, values)
 	}
+	s.step++
 }
 
 // Finalize the system

--- a/resource/doc.go
+++ b/resource/doc.go
@@ -1,0 +1,2 @@
+// Package resource provides commonly used resources (in the ECS sense).
+package resource

--- a/resource/resources.go
+++ b/resource/resources.go
@@ -1,4 +1,4 @@
-package model
+package resource
 
 import "golang.org/x/exp/rand"
 

--- a/resource/resources_test.go
+++ b/resource/resources_test.go
@@ -1,9 +1,10 @@
-package model_test
+package resource_test
 
 import (
 	"fmt"
 
 	"github.com/mlange-42/arche-model/model"
+	"github.com/mlange-42/arche-model/resource"
 	"github.com/mlange-42/arche/ecs"
 	"golang.org/x/exp/rand"
 )
@@ -11,7 +12,7 @@ import (
 func ExampleRand() {
 	m := model.New()
 
-	src := ecs.GetResource[model.Rand](&m.World)
+	src := ecs.GetResource[resource.Rand](&m.World)
 	rng := rand.New(src.Source)
 	_ = rng.NormFloat64()
 	// Output:
@@ -20,7 +21,7 @@ func ExampleRand() {
 func ExampleTick() {
 	m := model.New()
 
-	tick := ecs.GetResource[model.Tick](&m.World)
+	tick := ecs.GetResource[resource.Tick](&m.World)
 
 	fmt.Println(tick.Tick)
 	// Output: 0
@@ -29,7 +30,7 @@ func ExampleTick() {
 func ExampleTermination() {
 	m := model.New()
 
-	term := ecs.GetResource[model.Termination](&m.World)
+	term := ecs.GetResource[resource.Termination](&m.World)
 
 	fmt.Println(term.Terminate)
 	// Output: false

--- a/system/callback_termination.go
+++ b/system/callback_termination.go
@@ -9,23 +9,28 @@ import (
 // CallbackTermination system.
 //
 // Terminates a model run according to the return value of a callback function.
+//
+// Expects a resource of type [model.Termination].
 type CallbackTermination struct {
 	Callback func(t int64) bool // The callback. ends the simulation when it returns true.
-	timeRes  generic.Resource[model.Time]
+	termRes  generic.Resource[model.Termination]
+	step     int64
 }
 
 // Initialize the system
 func (s *CallbackTermination) Initialize(w *ecs.World) {
-	s.timeRes = generic.NewResource[model.Time](w)
+	s.termRes = generic.NewResource[model.Termination](w)
+	s.step = 0
 }
 
 // Update the system
 func (s *CallbackTermination) Update(w *ecs.World) {
-	time := s.timeRes.Get()
+	term := s.termRes.Get()
 
-	if s.Callback(time.Tick) {
-		time.Finished = true
+	if s.Callback(s.step) {
+		term.Terminate = true
 	}
+	s.step++
 }
 
 // Finalize the system

--- a/system/callback_termination.go
+++ b/system/callback_termination.go
@@ -1,7 +1,7 @@
 package system
 
 import (
-	"github.com/mlange-42/arche-model/model"
+	"github.com/mlange-42/arche-model/resource"
 	"github.com/mlange-42/arche/ecs"
 	"github.com/mlange-42/arche/generic"
 )
@@ -13,13 +13,13 @@ import (
 // Expects a resource of type [model.Termination].
 type CallbackTermination struct {
 	Callback func(t int64) bool // The callback. ends the simulation when it returns true.
-	termRes  generic.Resource[model.Termination]
+	termRes  generic.Resource[resource.Termination]
 	step     int64
 }
 
 // Initialize the system
 func (s *CallbackTermination) Initialize(w *ecs.World) {
-	s.termRes = generic.NewResource[model.Termination](w)
+	s.termRes = generic.NewResource[resource.Termination](w)
 	s.step = 0
 }
 

--- a/system/callback_termination_test.go
+++ b/system/callback_termination_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/mlange-42/arche-model/model"
+	"github.com/mlange-42/arche-model/resource"
 	"github.com/mlange-42/arche-model/system"
 	"github.com/mlange-42/arche/ecs"
 	"github.com/stretchr/testify/assert"
@@ -20,7 +21,7 @@ func TestCallbackTermination(t *testing.T) {
 
 	m.Run()
 
-	time := ecs.GetResource[model.Tick](&m.World)
+	time := ecs.GetResource[resource.Tick](&m.World)
 	assert.Equal(t, 100, int(time.Tick))
 }
 

--- a/system/callback_termination_test.go
+++ b/system/callback_termination_test.go
@@ -20,7 +20,7 @@ func TestCallbackTermination(t *testing.T) {
 
 	m.Run()
 
-	time := ecs.GetResource[model.Time](&m.World)
+	time := ecs.GetResource[model.Tick](&m.World)
 	assert.Equal(t, 100, int(time.Tick))
 }
 

--- a/system/fixed_termination.go
+++ b/system/fixed_termination.go
@@ -9,23 +9,28 @@ import (
 // FixedTermination system.
 //
 // Terminates a model run after a fixed number of ticks.
+//
+// Expects a resource of type [model.Termination].
 type FixedTermination struct {
 	Steps   int64 // Number of simulation ticks to run.
-	timeRes generic.Resource[model.Time]
+	termRes generic.Resource[model.Termination]
+	step    int64
 }
 
 // Initialize the system
 func (s *FixedTermination) Initialize(w *ecs.World) {
-	s.timeRes = generic.NewResource[model.Time](w)
+	s.termRes = generic.NewResource[model.Termination](w)
+	s.step = 0
 }
 
 // Update the system
 func (s *FixedTermination) Update(w *ecs.World) {
-	time := s.timeRes.Get()
+	term := s.termRes.Get()
 
-	if time.Tick+1 >= s.Steps {
-		time.Finished = true
+	if s.step+1 >= s.Steps {
+		term.Terminate = true
 	}
+	s.step++
 }
 
 // Finalize the system

--- a/system/fixed_termination.go
+++ b/system/fixed_termination.go
@@ -1,7 +1,7 @@
 package system
 
 import (
-	"github.com/mlange-42/arche-model/model"
+	"github.com/mlange-42/arche-model/resource"
 	"github.com/mlange-42/arche/ecs"
 	"github.com/mlange-42/arche/generic"
 )
@@ -13,13 +13,13 @@ import (
 // Expects a resource of type [model.Termination].
 type FixedTermination struct {
 	Steps   int64 // Number of simulation ticks to run.
-	termRes generic.Resource[model.Termination]
+	termRes generic.Resource[resource.Termination]
 	step    int64
 }
 
 // Initialize the system
 func (s *FixedTermination) Initialize(w *ecs.World) {
-	s.termRes = generic.NewResource[model.Termination](w)
+	s.termRes = generic.NewResource[resource.Termination](w)
 	s.step = 0
 }
 

--- a/system/fixed_termination_test.go
+++ b/system/fixed_termination_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/mlange-42/arche-model/model"
+	"github.com/mlange-42/arche-model/resource"
 	"github.com/mlange-42/arche-model/system"
 	"github.com/mlange-42/arche/ecs"
 	"github.com/stretchr/testify/assert"
@@ -16,7 +17,7 @@ func TestFixedTermination(t *testing.T) {
 
 	m.Run()
 
-	time := ecs.GetResource[model.Tick](&m.World)
+	time := ecs.GetResource[resource.Tick](&m.World)
 	assert.Equal(t, 100, int(time.Tick))
 }
 

--- a/system/fixed_termination_test.go
+++ b/system/fixed_termination_test.go
@@ -16,7 +16,7 @@ func TestFixedTermination(t *testing.T) {
 
 	m.Run()
 
-	time := ecs.GetResource[model.Time](&m.World)
+	time := ecs.GetResource[model.Tick](&m.World)
 	assert.Equal(t, 100, int(time.Tick))
 }
 

--- a/system/perf_timer.go
+++ b/system/perf_timer.go
@@ -4,9 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/mlange-42/arche-model/model"
 	"github.com/mlange-42/arche/ecs"
-	"github.com/mlange-42/arche/generic"
 )
 
 // PerfTimer system for printing elapsed time per model step, and optional world statistics.
@@ -14,33 +12,29 @@ type PerfTimer struct {
 	UpdateInterval int  // Update/print interval in model ticks.
 	Stats          bool // Whether to print world stats.
 	start          time.Time
-	step           int
-	timeRes        generic.Resource[model.Time]
+	step           int64
 }
 
 // Initialize the system
 func (s *PerfTimer) Initialize(w *ecs.World) {
-	s.timeRes = generic.NewResource[model.Time](w)
+	s.step = 0
 }
 
 // Update the system
 func (s *PerfTimer) Update(w *ecs.World) {
-	tm := s.timeRes.Get()
-
 	t := time.Now()
-	if tm.Tick == 0 {
+	if s.step == 0 {
 		s.start = t
 	}
-	if tm.Tick%int64(s.UpdateInterval) == 0 {
-		if tm.Tick > 0 {
+	if s.step%int64(s.UpdateInterval) == 0 {
+		if s.step > 0 {
 			dur := t.Sub(s.start)
-			usec := float64(dur.Microseconds()) / float64(s.step)
+			usec := float64(dur.Microseconds()) / float64(s.UpdateInterval)
 			fmt.Printf("%d updates, %0.2f us/update\n", s.UpdateInterval, usec)
 		}
 		if s.Stats {
 			fmt.Println(w.Stats().String())
 		}
-		s.step = 0
 		s.start = t
 	}
 	s.step++


### PR DESCRIPTION
- All resources moved from package `model` to `resource`
- Resource `Time` is now `Tick` and `Termination`
- Included systems count ticks internally and don't rely on `Time`
- Upgrade Arche dependency to v0.6.1
- Fix CHANGELOG compare link