### PR TITLE
More precise FPS/TPS timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [[v0.0.4]](https://github.com/mlange-42/arche-model/compare/v0.0.3...v0.0.4)
+
+### Other
+
+* Precise (average) FPS and TPS timing by using semi-cumulative time (#24)
+
 ## [[v0.0.3]](https://github.com/mlange-42/arche-model/compare/v0.0.2...v0.0.3)
 
 ### Breaking changes

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/mlange-42/arche-model
 go 1.20
 
 require (
-	github.com/mlange-42/arche v0.6.1
+	github.com/mlange-42/arche v0.6.2
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb
 )

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/mlange-42/arche v0.6.0 h1:xF/jlJeSjX1Yt7JdiGcPIS0q20ATqwbegU5cIP0/j4g
 github.com/mlange-42/arche v0.6.0/go.mod h1:cgOiMHWCbNAb5L5mCihS2yzdk1Zll1IoBJL+3wVm0AM=
 github.com/mlange-42/arche v0.6.1 h1:MA0VTHvlGxw44MRfj8qbHLnB5QQFAXueGYRiQgLGPVc=
 github.com/mlange-42/arche v0.6.1/go.mod h1:cgOiMHWCbNAb5L5mCihS2yzdk1Zll1IoBJL+3wVm0AM=
+github.com/mlange-42/arche v0.6.2 h1:yYCZmtCV0ZYZS09byflWszaJvIBERnF+3BZ9L6OSYas=
+github.com/mlange-42/arche v0.6.2/go.mod h1:cgOiMHWCbNAb5L5mCihS2yzdk1Zll1IoBJL+3wVm0AM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/model/systems.go
+++ b/model/systems.go
@@ -157,9 +157,8 @@ func (s *Systems) initialize() {
 	s.removeSystems()
 	s.initialized = true
 
-	t := time.Now()
-	s.nextDraw = t
-	s.nextUpdate = t
+	s.nextDraw = time.Time{}
+	s.nextUpdate = time.Time{}
 }
 
 // Update all systems.
@@ -175,7 +174,7 @@ func (s *Systems) update() {
 		time := s.tickRes.Get()
 		time.Tick++
 	} else {
-		//s.wait()
+		s.wait()
 	}
 }
 
@@ -194,7 +193,8 @@ func (s *Systems) wait() {
 
 	t := time.Now()
 	wait := nextUpdate.Sub(t)
-	if wait > 0 {
+	// Wait only if time is sufficiently long, as time.Sleep only guaranties minimum waiting time.
+	if wait > time.Millisecond {
 		time.Sleep(wait)
 	}
 }
@@ -217,18 +217,6 @@ func (s *Systems) updateSystems() bool {
 		}
 	}
 	return update
-}
-
-func nextTime(last time.Time, fps float64) time.Time {
-	if fps <= 0 {
-		return last
-	}
-	dt := time.Second / time.Duration(fps)
-	now := time.Now()
-	if now.After(last.Add(10 * dt)) {
-		return now
-	}
-	return last.Add(dt)
 }
 
 // Update UI systems.

--- a/model/util.go
+++ b/model/util.go
@@ -1,0 +1,16 @@
+package model
+
+import "time"
+
+// nextTime calculates the next intended update.
+func nextTime(last time.Time, fps float64) time.Time {
+	if fps <= 0 {
+		return last
+	}
+	dt := time.Second / time.Duration(fps)
+	now := time.Now()
+	if now.After(last.Add(10 * dt)) {
+		return now
+	}
+	return last.Add(dt)
+}

--- a/model/util_test.go
+++ b/model/util_test.go
@@ -1,0 +1,16 @@
+package model
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNextTime(t *testing.T) {
+	start := time.Now()
+
+	assert.Equal(t, start.Add(time.Second), nextTime(start, 1))
+	assert.Equal(t, start.Add(time.Second/2), nextTime(start, 2))
+	assert.Equal(t, start.Add(time.Second/60), nextTime(start, 60))
+}


### PR DESCRIPTION
More precise FPS and TPS by looping to wait short amounts of time instead of relying on `time.Sleep()`.

Fixes #25