### PR TITLE
Implement pausing a simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [[v0.0.4]](https://github.com/mlange-42/arche-model/compare/v0.0.4...v0.0.5)
+
+### Features
+
+* Simulations can be paused through the `Systems` resource (#25)
+
 ## [[v0.0.4]](https://github.com/mlange-42/arche-model/compare/v0.0.3...v0.0.4)
 
 ### Other

--- a/resource/resources.go
+++ b/resource/resources.go
@@ -12,7 +12,7 @@ type Tick struct {
 	Tick int64 // The current model tick.
 }
 
-// Termination is a resource holding a whether the system should terminate after the current step.
+// Termination is a resource holding whether the simulation should terminate after the current step.
 type Termination struct {
-	Terminate bool // Whether the model run is finished. Can be set by systems.
+	Terminate bool // Whether the simulation run is finished. Can be set by systems.
 }


### PR DESCRIPTION
The resource (and scheduler) `Systems` has a property `Paused`, which pauses normal updates while continuing to update the UI.