### PR TITLE
Rename abbreviated fields in `Systems` for Go style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [[v0.0.4]](https://github.com/mlange-42/arche-model/compare/v0.0.4...v0.0.5)
 
+### Breaking changes
+
+* Renamed `Systems.Fps` and `Systems.Tps` to `Systems.FPS` and `Systems.TPS` (#26)
+
 ### Features
 
 * Simulations can be paused through the `Systems` resource (#25)

--- a/model/model.go
+++ b/model/model.go
@@ -12,9 +12,9 @@ import (
 //
 // Model provides access to the ECS world, and manages the scheduling
 // of [System] and [UISystem] instances via [Systems].
-// [System] instances are updated with a frequency given by Tps.
+// [System] instances are updated with a frequency given by TPS.
 // [UISystem] instances are updated independently of normal systems,
-// with a frequency given by Fps.
+// with a frequency given by FPS.
 //
 // The [Systems] scheduler, the model's [resource.Tick], [resource.Termination]
 // and a central [resource.Rand] PRNG source can be accessed by systems as resources.
@@ -31,8 +31,8 @@ func New(config ...ecs.Config) *Model {
 	var mod = Model{
 		World: ecs.NewWorld(config...),
 	}
-	mod.Fps = 30
-	mod.Tps = 0
+	mod.FPS = 30
+	mod.TPS = 0
 	mod.Systems.world = &mod.World
 
 	mod.rand = resource.Rand{

--- a/model/systems_test.go
+++ b/model/systems_test.go
@@ -16,8 +16,8 @@ func TestSystems(t *testing.T) {
 
 		m.Seed()
 		m.Seed(123)
-		m.Tps = 120
-		m.Fps = 60
+		m.TPS = 120
+		m.FPS = 60
 
 		termSys := system.FixedTermination{
 			Steps: 1000,


### PR DESCRIPTION
rename Systems Tps and Fps to TPS and FPS