### PR TITLE
FPS defaults to 30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Renamed `Systems.Fps` and `Systems.Tps` to `Systems.FPS` and `Systems.TPS` (#26)
 
+### Other
+
+* Unset/zero `Model.FPS` sets to 30 FPS, as a default more useful than synced with TPS (#27)
+
 ### Features
 
 * Simulations can be paused through the `Systems` resource (#25)

--- a/model/systems.go
+++ b/model/systems.go
@@ -36,8 +36,8 @@ type UISystem interface {
 // [Systems] is an embed in [Model] and it's methods are usually only used through a [Model] instance.
 // By also being a resource of each [Model], however, systems can access it and e.g. remove themselves from a model.
 type Systems struct {
-	FPS    float64 // Frames per second for UI systems. Values <= 0 (the default) sync FPS with TPS.
 	TPS    float64 // Ticks per second for normal systems. Values <= 0 (the default) mean as fast as possible.
+	FPS    float64 // Frames per second for UI systems. A zero/unset value defaults to 30 FPS. Values < 0 sync FPS with TPS.
 	Paused bool    // Whether the simulation is currently paused. When paused, only UI updates but no normal updates are performed.
 
 	world      *ecs.World
@@ -141,12 +141,17 @@ func (s *Systems) removeSystems() {
 
 // Initialize all systems.
 func (s *Systems) initialize() {
-	s.tickRes = generic.NewResource[resource.Tick](s.world)
-	s.termRes = generic.NewResource[resource.Termination](s.world)
-
 	if s.initialized {
 		panic("model is already initialized")
 	}
+
+	if s.FPS == 0 {
+		s.FPS = 30
+	}
+
+	s.tickRes = generic.NewResource[resource.Tick](s.world)
+	s.termRes = generic.NewResource[resource.Termination](s.world)
+
 	s.locked = true
 	for _, sys := range s.systems {
 		sys.Initialize(s.world)

--- a/model/systems_test.go
+++ b/model/systems_test.go
@@ -49,6 +49,15 @@ func TestSystems(t *testing.T) {
 	}
 }
 
+func TestSystemsInit(t *testing.T) {
+	m := model.New()
+	m.AddSystem(&system.FixedTermination{Steps: 1})
+	m.Run()
+
+	assert.Equal(t, 30.0, m.FPS)
+	assert.Equal(t, 0.0, m.TPS)
+}
+
 type uiSystem struct{}
 
 func (s *uiSystem) InitializeUI(w *ecs.World) {}


### PR DESCRIPTION
- Unset/zero `Model.FPS` sets to 30 FPS, as a default more useful than synced with TPS