### PR TITLE
More precise TPS for very high target TPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Other
 
 * Brings test coverage to 95%, adds test coverage badge (#30)
+* More precise TPS when simulation does not reach target TPS (#31)
 
 ## [[v0.0.5]](https://github.com/mlange-42/arche-model/compare/v0.0.4...v0.0.5)
 

--- a/model/systems.go
+++ b/model/systems.go
@@ -206,15 +206,10 @@ func (s *Systems) update() {
 
 // Calculates and waits the time until the next update of UI update.
 func (s *Systems) wait() {
-	var nextUpdate time.Time
-	if s.TPS > 0 {
-		nextUpdate = s.nextUpdate
-	}
+	nextUpdate := s.nextUpdate
+
 	if (s.Paused || s.FPS > 0) && s.nextDraw.Before(nextUpdate) {
 		nextUpdate = s.nextDraw
-	}
-	if nextUpdate.IsZero() {
-		return
 	}
 
 	t := time.Now()

--- a/model/util.go
+++ b/model/util.go
@@ -9,8 +9,8 @@ func nextTime(last time.Time, fps float64) time.Time {
 	}
 	dt := time.Second / time.Duration(fps)
 	now := time.Now()
-	if now.After(last.Add(10 * dt)) {
-		return now
+	if now.After(last.Add(200 * time.Millisecond)) {
+		return now.Add(-10 * time.Millisecond)
 	}
 	return last.Add(dt)
 }


### PR DESCRIPTION
Fix for more precise TPS when target TPS is not reached.

Before the fix, the simulations were running slower for very high TPS, compared to with TPS=0 (i.e. unlimited)