### PR TITLE
Single grid coords & MatrixToGrid observer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## [[v0.3.0]](https://github.com/mlange-42/arche-model/compare/v0.2.0...v0.3.0)
 
+### Breaking changes
+
+* Methods `observer.Grid.X` and `observer.Grid.Y` take an `int` argument and return one value instead of all (#38)
+
 ### Features
 
 * Observer `RowToTable` as adapter from `Row` to `Table` observer (#37)
+* Observer `MatrixToGrid` as adapter from `Matrix` to `Grid` observer (#38)
 * System `PerfTimer` prints total step and average time per tick on finalization (#37)
 
 ## [[v0.2.0]](https://github.com/mlange-42/arche-model/compare/v0.1.0...v0.2.0)

--- a/observer/matrix_to_grid.go
+++ b/observer/matrix_to_grid.go
@@ -1,0 +1,49 @@
+package observer
+
+import (
+	"github.com/mlange-42/arche/ecs"
+)
+
+// MatrixToGrid is an observer that serves as adapter from a [Matrix] observer to a [Grid] observer.
+type MatrixToGrid struct {
+	Observer Matrix     // The wrapped Matrix observer.
+	Origin   [2]float64 // Origin. Optional, defaults to (0, 0)
+	CellSize [2]float64 // CellSize. Optional, defaults to (1, 1).
+}
+
+// Initialize the child observer.
+func (o *MatrixToGrid) Initialize(w *ecs.World) {
+	o.Observer.Initialize(w)
+
+	if o.CellSize[0] == 0 {
+		o.CellSize[0] = 1
+	}
+	if o.CellSize[1] == 0 {
+		o.CellSize[1] = 1
+	}
+}
+
+// Update the child observer.
+func (o *MatrixToGrid) Update(w *ecs.World) {
+	o.Observer.Update(w)
+}
+
+// Dims returns the matrix dimensions.
+func (o *MatrixToGrid) Dims() (int, int) {
+	return o.Observer.Dims()
+}
+
+// Values for the current model tick.
+func (o *MatrixToGrid) Values(w *ecs.World) []float64 {
+	return o.Observer.Values(w)
+}
+
+// X axis coordinates.
+func (o *MatrixToGrid) X(c int) float64 {
+	return o.Origin[0] + o.CellSize[0]*float64(c)
+}
+
+// Y axis coordinates.
+func (o *MatrixToGrid) Y(r int) float64 {
+	return o.Origin[1] + o.CellSize[1]*float64(r)
+}

--- a/observer/matrix_to_grid_test.go
+++ b/observer/matrix_to_grid_test.go
@@ -1,0 +1,62 @@
+package observer_test
+
+import (
+	"testing"
+
+	"github.com/mlange-42/arche-model/model"
+	"github.com/mlange-42/arche-model/observer"
+	"github.com/mlange-42/arche/ecs"
+	"github.com/stretchr/testify/assert"
+)
+
+type matObs struct {
+	values []float64
+}
+
+func (o *matObs) Initialize(w *ecs.World) {
+	o.values = make([]float64, 20*30)
+}
+
+func (o *matObs) Update(w *ecs.World) {}
+
+func (o *matObs) Dims() (int, int) {
+	return 30, 20
+}
+
+func (o *matObs) Values(w *ecs.World) []float64 {
+	return o.values
+}
+
+func TestMatrixToGrid(t *testing.T) {
+	m := model.New()
+
+	var mat observer.Matrix = &matObs{}
+	var grid observer.Grid = &observer.MatrixToGrid{
+		Observer: mat,
+		Origin:   [...]float64{1, 2},
+		CellSize: [...]float64{5, 10},
+	}
+
+	grid.Initialize(&m.World)
+	grid.Update(&m.World)
+
+	v := grid.Values(&m.World)
+	assert.Equal(t, make([]float64, 20*30), v)
+
+	w, h := grid.Dims()
+	assert.Equal(t, 30, w)
+	assert.Equal(t, 20, h)
+
+	assert.Equal(t, 1.0, grid.X(0))
+	assert.Equal(t, 2.0, grid.Y(0))
+
+	assert.Equal(t, 6.0, grid.X(1))
+	assert.Equal(t, 12.0, grid.Y(1))
+
+	grid = &observer.MatrixToGrid{
+		Observer: mat,
+	}
+	grid.Initialize(&m.World)
+	assert.Equal(t, 1.0, grid.X(1))
+	assert.Equal(t, 1.0, grid.Y(1))
+}

--- a/observer/observer.go
+++ b/observer/observer.go
@@ -38,7 +38,7 @@ type Matrix interface {
 //
 // See also [Matrix]. See package [github.com/mlange-42/arche-model/reporter] for usage examples.
 type Grid interface {
-	Matrix        // Methods from Matrix observer.
-	X() []float64 // X axis values.
-	Y() []float64 // Y axis values.
+	Matrix           // Methods from Matrix observer.
+	X(c int) float64 // X axis coordinates.
+	Y(r int) float64 // Y axis coordinates.
 }

--- a/observer/observer_grid_test.go
+++ b/observer/observer_grid_test.go
@@ -13,8 +13,6 @@ type GridObserver struct {
 	cellsize float64
 	xOrigin  float64
 	yOrigin  float64
-	x        []float64
-	y        []float64
 	values   []float64
 }
 
@@ -27,16 +25,7 @@ func (o *GridObserver) Initialize(w *ecs.World) {
 	o.xOrigin = 123_000
 	o.yOrigin = 234_000
 
-	o.x = make([]float64, o.cols)
-	o.y = make([]float64, o.rows)
 	o.values = make([]float64, o.cols*o.rows)
-
-	for i := 0; i < o.cols; i++ {
-		o.x[i] = o.xOrigin + o.cellsize*float64(i)
-	}
-	for i := 0; i < o.cols; i++ {
-		o.y[i] = o.yOrigin + o.cellsize*float64(i)
-	}
 }
 
 func (o *GridObserver) Update(w *ecs.World) {}
@@ -45,18 +34,18 @@ func (o *GridObserver) Dims() (int, int) {
 	return o.cols, o.rows
 }
 
-func (o *GridObserver) X() []float64 {
-	return o.x
+func (o *GridObserver) X(c int) float64 {
+	return o.xOrigin + o.cellsize*float64(c)
 }
 
-func (o *GridObserver) Y() []float64 {
-	return o.y
+func (o *GridObserver) Y(r int) float64 {
+	return o.yOrigin + o.cellsize*float64(r)
 }
 
 func (o *GridObserver) Values(w *ecs.World) []float64 {
 	for idx := 0; idx < len(o.values); idx++ {
-		x := o.x[idx%o.cols]
-		y := o.y[idx/o.cols]
+		x := o.X(idx % o.cols)
+		y := o.Y(idx / o.cols)
 		o.values[idx] = float64(x*x + y)
 	}
 	return o.values

--- a/observer/observer_matrix_to_grid_test.go
+++ b/observer/observer_matrix_to_grid_test.go
@@ -1,0 +1,23 @@
+package observer_test
+
+import (
+	"github.com/mlange-42/arche-model/model"
+	"github.com/mlange-42/arche-model/observer"
+)
+
+func ExampleMatrixToGrid() {
+	m := model.New()
+
+	// A Matrix observer
+	var matrix observer.Matrix = &MatrixObserver{}
+	var _ []float64 = matrix.Values(&m.World)
+
+	// A MatrixToGrid observer, wrapping the Matrix observer
+	var grid observer.Grid = &observer.MatrixToGrid{
+		Observer: matrix,
+		Origin:   [...]float64{100, 200},
+		CellSize: [...]float64{1000, 1000},
+	}
+	var _ []float64 = grid.Values(&m.World)
+	// Output:
+}

--- a/observer/row_to_table_test.go
+++ b/observer/row_to_table_test.go
@@ -29,12 +29,12 @@ func (o *rowObs) Values(w *ecs.World) []float64 {
 func TestRowToTable(t *testing.T) {
 	m := model.New()
 
-	row := rowObs{
+	var row observer.Row = &rowObs{
 		header: []string{"A", "B"},
 		values: []float64{1, 2},
 	}
 
-	table := observer.RowToTable{Observer: &row}
+	var table observer.Table = &observer.RowToTable{Observer: row}
 
 	table.Initialize(&m.World)
 	table.Update(&m.World)


### PR DESCRIPTION
* Methods `observer.Grid.X` and `observer.Grid.Y` take an `int` argument and return one value instead of all
* Observer `MatrixToGrid` as adapter from `Matrix` to `Grid` observer