### PR TITLE
Multi-layer Matrix and Grid observers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 * Observer `RowToTable` as adapter from `Row` to `Table` observer (#37)
 * Observer `MatrixToGrid` as adapter from `Matrix` to `Grid` observer (#38)
+* Observer interfaces `MatrixLayers` and `GridLayers` for multi-layered matrices and grids (#39)
+* Observers `MatrixToLayers`, `GridToLayers` and `LayersToGrid` as adapters (#39)
 * System `PerfTimer` prints total step and average time per tick on finalization (#37)
 
 ## [[v0.2.0]](https://github.com/mlange-42/arche-model/compare/v0.1.0...v0.2.0)

--- a/observer/grid_to_layers.go
+++ b/observer/grid_to_layers.go
@@ -1,0 +1,67 @@
+package observer
+
+import "github.com/mlange-42/arche/ecs"
+
+// GridToLayers is an observer that serves as adapter from multiple [Grid] observers to a [GridLayers] observer.
+type GridToLayers struct {
+	Observers []Grid
+	values    [][]float64
+}
+
+// Initialize the child observer.
+func (o *GridToLayers) Initialize(w *ecs.World) {
+	if len(o.Observers) == 0 {
+		panic("no observers given")
+	}
+
+	for i, obs := range o.Observers {
+		obs.Initialize(w)
+		if i == 0 {
+			continue
+		}
+		obs0 := o.Observers[0]
+		w1, h1 := obs0.Dims()
+		w2, h2 := obs.Dims()
+
+		if w1 != w2 || h1 != h2 {
+			panic("grids for layers have different dimensions")
+		}
+	}
+
+	o.values = make([][]float64, len(o.Observers))
+}
+
+// Update the child observer.
+func (o *GridToLayers) Update(w *ecs.World) {
+	for _, obs := range o.Observers {
+		obs.Update(w)
+	}
+}
+
+// Dims returns the matrix dimensions.
+func (o *GridToLayers) Dims() (int, int) {
+	return o.Observers[0].Dims()
+}
+
+// Layers returns the number of layers.
+func (o *GridToLayers) Layers() int {
+	return len(o.Observers)
+}
+
+// Values for the current model tick.
+func (o *GridToLayers) Values(w *ecs.World) [][]float64 {
+	for i, obs := range o.Observers {
+		o.values[i] = obs.Values(w)
+	}
+	return o.values
+}
+
+// X axis coordinates.
+func (o *GridToLayers) X(c int) float64 {
+	return o.Observers[0].X(c)
+}
+
+// Y axis coordinates.
+func (o *GridToLayers) Y(r int) float64 {
+	return o.Observers[0].Y(r)
+}

--- a/observer/grid_to_layers_test.go
+++ b/observer/grid_to_layers_test.go
@@ -1,0 +1,67 @@
+package observer_test
+
+import (
+	"testing"
+
+	"github.com/mlange-42/arche-model/model"
+	"github.com/mlange-42/arche-model/observer"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGridToLayers(t *testing.T) {
+	m := model.New()
+
+	var mat1 observer.Matrix = &matObs{}
+	var mat2 observer.Matrix = &matObs{}
+	var mat3 observer.Matrix = &matObs{}
+
+	var grid1 observer.Grid = &observer.MatrixToGrid{Observer: mat1}
+	var grid2 observer.Grid = &observer.MatrixToGrid{Observer: mat2}
+	var grid3 observer.Grid = &observer.MatrixToGrid{Observer: mat3}
+
+	var layers observer.GridLayers = &observer.GridToLayers{
+		Observers: []observer.Grid{
+			grid1, grid2, grid3,
+		},
+	}
+
+	layers.Initialize(&m.World)
+	layers.Update(&m.World)
+
+	assert.Equal(t, 3, layers.Layers())
+
+	w, h := layers.Dims()
+
+	assert.Equal(t, 30, w)
+	assert.Equal(t, 20, h)
+
+	assert.Equal(t, 1.0, layers.X(1))
+	assert.Equal(t, 1.0, layers.Y(1))
+
+	data := layers.Values(&m.World)
+	assert.Equal(t, 3, len(data))
+	assert.Equal(t, 20*30, len(data[0]))
+}
+
+func TestGridToLayersFail(t *testing.T) {
+	m := model.New()
+
+	var mat1 observer.Matrix = &matObs{}
+	var mat2 *matObs = &matObs{}
+	mat2.Rows = 15
+
+	var grid1 observer.Grid = &observer.MatrixToGrid{Observer: mat1}
+	var grid2 observer.Grid = &observer.MatrixToGrid{Observer: mat2}
+
+	var layers observer.GridLayers = &observer.GridToLayers{
+		Observers: []observer.Grid{
+			grid1, grid2,
+		},
+	}
+	assert.Panics(t, func() { layers.Initialize(&m.World) })
+
+	layers = &observer.GridToLayers{
+		Observers: []observer.Grid{},
+	}
+	assert.Panics(t, func() { layers.Initialize(&m.World) })
+}

--- a/observer/layers_to_grid.go
+++ b/observer/layers_to_grid.go
@@ -1,0 +1,54 @@
+package observer
+
+import (
+	"github.com/mlange-42/arche/ecs"
+)
+
+// LayersToGrid is an observer that serves as adapter from a [MatrixLayers] observer to a [GridLayers] observer.
+type LayersToGrid struct {
+	Observer MatrixLayers // The wrapped MatrixLayers observers.
+	Origin   [2]float64   // Origin. Optional, defaults to (0, 0)
+	CellSize [2]float64   // CellSize. Optional, defaults to (1, 1).
+}
+
+// Initialize the child observer.
+func (o *LayersToGrid) Initialize(w *ecs.World) {
+	o.Observer.Initialize(w)
+
+	if o.CellSize[0] == 0 {
+		o.CellSize[0] = 1
+	}
+	if o.CellSize[1] == 0 {
+		o.CellSize[1] = 1
+	}
+}
+
+// Update the child observer.
+func (o *LayersToGrid) Update(w *ecs.World) {
+	o.Observer.Update(w)
+}
+
+// Dims returns the matrix dimensions.
+func (o *LayersToGrid) Dims() (int, int) {
+	return o.Observer.Dims()
+}
+
+// Layers returns the number of layers.
+func (o *LayersToGrid) Layers() int {
+	return o.Observer.Layers()
+}
+
+// Values for the current model tick.
+func (o *LayersToGrid) Values(w *ecs.World) [][]float64 {
+	return o.Observer.Values(w)
+}
+
+// X axis coordinates.
+func (o *LayersToGrid) X(c int) float64 {
+	return o.Origin[0] + o.CellSize[0]*float64(c)
+}
+
+// Y axis coordinates.
+func (o *LayersToGrid) Y(r int) float64 {
+	return o.Origin[1] + o.CellSize[1]*float64(r)
+}

--- a/observer/layers_to_grid_test.go
+++ b/observer/layers_to_grid_test.go
@@ -1,0 +1,44 @@
+package observer_test
+
+import (
+	"testing"
+
+	"github.com/mlange-42/arche-model/model"
+	"github.com/mlange-42/arche-model/observer"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLayersToGrid(t *testing.T) {
+	m := model.New()
+
+	var mat1 observer.Matrix = &matObs{}
+	var mat2 observer.Matrix = &matObs{}
+	var mat3 observer.Matrix = &matObs{}
+
+	var layers observer.MatrixLayers = &observer.MatrixToLayers{
+		Observers: []observer.Matrix{
+			mat1, mat2, mat3,
+		},
+	}
+
+	var grid observer.GridLayers = &observer.LayersToGrid{
+		Observer: layers,
+	}
+
+	grid.Initialize(&m.World)
+	grid.Update(&m.World)
+
+	assert.Equal(t, 3, grid.Layers())
+
+	w, h := grid.Dims()
+
+	assert.Equal(t, 30, w)
+	assert.Equal(t, 20, h)
+
+	assert.Equal(t, 1.0, grid.X(1))
+	assert.Equal(t, 1.0, grid.Y(1))
+
+	data := grid.Values(&m.World)
+	assert.Equal(t, 3, len(data))
+	assert.Equal(t, 20*30, len(data[0]))
+}

--- a/observer/matrix_to_grid_test.go
+++ b/observer/matrix_to_grid_test.go
@@ -11,16 +11,24 @@ import (
 
 type matObs struct {
 	values []float64
+	Cols   int
+	Rows   int
 }
 
 func (o *matObs) Initialize(w *ecs.World) {
-	o.values = make([]float64, 20*30)
+	if o.Cols == 0 {
+		o.Cols = 30
+	}
+	if o.Rows == 0 {
+		o.Rows = 20
+	}
+	o.values = make([]float64, o.Cols*o.Rows)
 }
 
 func (o *matObs) Update(w *ecs.World) {}
 
 func (o *matObs) Dims() (int, int) {
-	return 30, 20
+	return o.Cols, o.Rows
 }
 
 func (o *matObs) Values(w *ecs.World) []float64 {
@@ -59,4 +67,7 @@ func TestMatrixToGrid(t *testing.T) {
 	grid.Initialize(&m.World)
 	assert.Equal(t, 1.0, grid.X(1))
 	assert.Equal(t, 1.0, grid.Y(1))
+
+	data := grid.Values(&m.World)
+	assert.Equal(t, 20*30, len(data))
 }

--- a/observer/matrix_to_layers.go
+++ b/observer/matrix_to_layers.go
@@ -1,0 +1,57 @@
+package observer
+
+import "github.com/mlange-42/arche/ecs"
+
+// MatrixToLayers is an observer that serves as adapter from multiple [Matrix] observers to a [MatrixLayers] observer.
+type MatrixToLayers struct {
+	Observers []Matrix
+	values    [][]float64
+}
+
+// Initialize the child observer.
+func (o *MatrixToLayers) Initialize(w *ecs.World) {
+	if len(o.Observers) == 0 {
+		panic("no observers given")
+	}
+
+	for i, obs := range o.Observers {
+		obs.Initialize(w)
+		if i == 0 {
+			continue
+		}
+		obs0 := o.Observers[0]
+		w1, h1 := obs0.Dims()
+		w2, h2 := obs.Dims()
+
+		if w1 != w2 || h1 != h2 {
+			panic("grids for layers have different dimensions")
+		}
+	}
+
+	o.values = make([][]float64, len(o.Observers))
+}
+
+// Update the child observer.
+func (o *MatrixToLayers) Update(w *ecs.World) {
+	for _, obs := range o.Observers {
+		obs.Update(w)
+	}
+}
+
+// Dims returns the matrix dimensions.
+func (o *MatrixToLayers) Dims() (int, int) {
+	return o.Observers[0].Dims()
+}
+
+// Layers returns the number of layers.
+func (o *MatrixToLayers) Layers() int {
+	return len(o.Observers)
+}
+
+// Values for the current model tick.
+func (o *MatrixToLayers) Values(w *ecs.World) [][]float64 {
+	for i, obs := range o.Observers {
+		o.values[i] = obs.Values(w)
+	}
+	return o.values
+}

--- a/observer/matrix_to_layers_test.go
+++ b/observer/matrix_to_layers_test.go
@@ -1,0 +1,57 @@
+package observer_test
+
+import (
+	"testing"
+
+	"github.com/mlange-42/arche-model/model"
+	"github.com/mlange-42/arche-model/observer"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatrixToLayers(t *testing.T) {
+	m := model.New()
+
+	var mat1 observer.Matrix = &matObs{}
+	var mat2 observer.Matrix = &matObs{}
+	var mat3 observer.Matrix = &matObs{}
+
+	var layers observer.MatrixLayers = &observer.MatrixToLayers{
+		Observers: []observer.Matrix{
+			mat1, mat2, mat3,
+		},
+	}
+
+	layers.Initialize(&m.World)
+	layers.Update(&m.World)
+
+	assert.Equal(t, 3, layers.Layers())
+
+	w, h := layers.Dims()
+
+	assert.Equal(t, 30, w)
+	assert.Equal(t, 20, h)
+
+	data := layers.Values(&m.World)
+	assert.Equal(t, 3, len(data))
+	assert.Equal(t, 20*30, len(data[0]))
+}
+
+func TestMatrixToLayersFail(t *testing.T) {
+	m := model.New()
+
+	var mat1 observer.Matrix = &matObs{}
+	var mat2 *matObs = &matObs{}
+	mat2.Rows = 15
+
+	var layers observer.MatrixLayers = &observer.MatrixToLayers{
+		Observers: []observer.Matrix{
+			mat1, mat2,
+		},
+	}
+	assert.Panics(t, func() { layers.Initialize(&m.World) })
+
+	layers = &observer.MatrixToLayers{
+		Observers: []observer.Matrix{},
+	}
+	assert.Panics(t, func() { layers.Initialize(&m.World) })
+}

--- a/observer/observer.go
+++ b/observer/observer.go
@@ -34,11 +34,31 @@ type Matrix interface {
 	Values(w *ecs.World) []float64 // Values for the current model tick, in row-major order (i.e. idx = row*ncols + col).
 }
 
+// MatrixLayers observer interface. Provides dimensionality, and multiple matrices of values per call.
+//
+// See also [Matrix] and [GridLayers]. See package [github.com/mlange-42/arche-model/reporter] for usage examples.
+type MatrixLayers interface {
+	Initialize(w *ecs.World)         // Initialize the observer. No other methods are called before this.
+	Update(w *ecs.World)             // Update the observer.
+	Layers() int                     // Number of layers.
+	Dims() (int, int)                // Matrix dimensions.
+	Values(w *ecs.World) [][]float64 // Values for the current model tick, in row-major order (i.e. idx = row*ncols + col). First index is the layer.
+}
+
 // Grid observer interface. Provides dimensionality, axis information, and a matrix of values per call.
 //
-// See also [Matrix]. See package [github.com/mlange-42/arche-model/reporter] for usage examples.
+// See also [Matrix] and [GridLayers]. See package [github.com/mlange-42/arche-model/reporter] for usage examples.
 type Grid interface {
 	Matrix           // Methods from Matrix observer.
+	X(c int) float64 // X axis coordinates.
+	Y(r int) float64 // Y axis coordinates.
+}
+
+// GridLayers observer interface. Provides dimensionality, axis information, and multiple matrices of values per call.
+//
+// See also [Grid], [Matrix] and [GridLayers]. See package [github.com/mlange-42/arche-model/reporter] for usage examples.
+type GridLayers interface {
+	MatrixLayers     // Methods from Matrix observer.
 	X(c int) float64 // X axis coordinates.
 	Y(r int) float64 // Y axis coordinates.
 }

--- a/observer/observer_grid_test.go
+++ b/observer/observer_grid_test.go
@@ -1,7 +1,6 @@
 package observer_test
 
 import (
-	"github.com/mlange-42/arche-model/model"
 	"github.com/mlange-42/arche-model/observer"
 	"github.com/mlange-42/arche/ecs"
 )
@@ -52,9 +51,6 @@ func (o *GridObserver) Values(w *ecs.World) []float64 {
 }
 
 func ExampleGrid() {
-	m := model.New()
-
-	var obs observer.Grid = &GridObserver{}
-	_ = obs.Values(&m.World)
+	var _ observer.Grid = &GridObserver{}
 	// Output:
 }

--- a/observer/observer_grid_to_layers_test.go
+++ b/observer/observer_grid_to_layers_test.go
@@ -1,0 +1,18 @@
+package observer_test
+
+import (
+	"github.com/mlange-42/arche-model/observer"
+)
+
+func ExampleGridToLayers() {
+	// Multiple Grid observers
+	var grid1 observer.Grid = &GridObserver{}
+	var grid2 observer.Grid = &GridObserver{}
+	var grid3 observer.Grid = &GridObserver{}
+
+	// A MatrixToGrid observer, wrapping the Grid observers
+	var _ observer.GridLayers = &observer.GridToLayers{
+		Observers: []observer.Grid{grid1, grid2, grid3},
+	}
+	// Output:
+}

--- a/observer/observer_layers_to_grid_test.go
+++ b/observer/observer_layers_to_grid_test.go
@@ -1,0 +1,23 @@
+package observer_test
+
+import (
+	"github.com/mlange-42/arche-model/observer"
+)
+
+func ExampleLayersToGrid() {
+	// Multiple Matrix observers
+	var matrix1 observer.Matrix = &MatrixObserver{}
+	var matrix2 observer.Matrix = &MatrixObserver{}
+	var matrix3 observer.Matrix = &MatrixObserver{}
+
+	// A MatrixToGrid observer, wrapping the Matrix observers
+	var layers observer.MatrixLayers = &observer.MatrixToLayers{
+		Observers: []observer.Matrix{matrix1, matrix2, matrix3},
+	}
+
+	// A GridLayers observer, wrapping the MatrixLayers observer
+	var _ observer.GridLayers = &observer.LayersToGrid{
+		Observer: layers,
+	}
+	// Output:
+}

--- a/observer/observer_matrix_test.go
+++ b/observer/observer_matrix_test.go
@@ -1,7 +1,6 @@
 package observer_test
 
 import (
-	"github.com/mlange-42/arche-model/model"
 	"github.com/mlange-42/arche-model/observer"
 	"github.com/mlange-42/arche/ecs"
 )
@@ -35,9 +34,6 @@ func (o *MatrixObserver) Values(w *ecs.World) []float64 {
 }
 
 func ExampleMatrix() {
-	m := model.New()
-
-	var obs observer.Matrix = &MatrixObserver{}
-	_ = obs.Values(&m.World)
+	var _ observer.Matrix = &MatrixObserver{}
 	// Output:
 }

--- a/observer/observer_matrix_to_grid_test.go
+++ b/observer/observer_matrix_to_grid_test.go
@@ -1,23 +1,18 @@
 package observer_test
 
 import (
-	"github.com/mlange-42/arche-model/model"
 	"github.com/mlange-42/arche-model/observer"
 )
 
 func ExampleMatrixToGrid() {
-	m := model.New()
-
 	// A Matrix observer
 	var matrix observer.Matrix = &MatrixObserver{}
-	var _ []float64 = matrix.Values(&m.World)
 
 	// A MatrixToGrid observer, wrapping the Matrix observer
-	var grid observer.Grid = &observer.MatrixToGrid{
+	var _ observer.Grid = &observer.MatrixToGrid{
 		Observer: matrix,
 		Origin:   [...]float64{100, 200},
 		CellSize: [...]float64{1000, 1000},
 	}
-	var _ []float64 = grid.Values(&m.World)
 	// Output:
 }

--- a/observer/observer_matrix_to_layers_test.go
+++ b/observer/observer_matrix_to_layers_test.go
@@ -1,0 +1,18 @@
+package observer_test
+
+import (
+	"github.com/mlange-42/arche-model/observer"
+)
+
+func ExampleMatrixToLayers() {
+	// Multiple Matrix observers
+	var matrix1 observer.Matrix = &MatrixObserver{}
+	var matrix2 observer.Matrix = &MatrixObserver{}
+	var matrix3 observer.Matrix = &MatrixObserver{}
+
+	// A MatrixToGrid observer, wrapping the Matrix observers
+	var _ observer.MatrixLayers = &observer.MatrixToLayers{
+		Observers: []observer.Matrix{matrix1, matrix2, matrix3},
+	}
+	// Output:
+}

--- a/observer/observer_row_test.go
+++ b/observer/observer_row_test.go
@@ -1,7 +1,6 @@
 package observer_test
 
 import (
-	"github.com/mlange-42/arche-model/model"
 	"github.com/mlange-42/arche-model/observer"
 	"github.com/mlange-42/arche/ecs"
 )
@@ -26,9 +25,6 @@ func (o *RowObserver) Values(w *ecs.World) []float64 {
 }
 
 func ExampleRow() {
-	m := model.New()
-
-	var obs observer.Row = &RowObserver{}
-	_ = obs.Values(&m.World)
+	var _ observer.Row = &RowObserver{}
 	// Output:
 }

--- a/observer/observer_row_to_table_test.go
+++ b/observer/observer_row_to_table_test.go
@@ -1,19 +1,14 @@
 package observer_test
 
 import (
-	"github.com/mlange-42/arche-model/model"
 	"github.com/mlange-42/arche-model/observer"
 )
 
 func ExampleRowToTable() {
-	m := model.New()
-
 	// A Row observer
 	var row observer.Row = &RowObserver{}
-	var _ []float64 = row.Values(&m.World)
 
 	// A RowToTable observer, wrapping the Row observer
-	var table observer.Table = &observer.RowToTable{Observer: row}
-	var _ [][]float64 = table.Values(&m.World)
+	var _ observer.Table = &observer.RowToTable{Observer: row}
 	// Output:
 }

--- a/observer/observer_table_test.go
+++ b/observer/observer_table_test.go
@@ -1,7 +1,6 @@
 package observer_test
 
 import (
-	"github.com/mlange-42/arche-model/model"
 	"github.com/mlange-42/arche-model/observer"
 	"github.com/mlange-42/arche/ecs"
 )
@@ -27,9 +26,6 @@ func (o *TableObserver) Values(w *ecs.World) [][]float64 {
 }
 
 func ExampleTable() {
-	m := model.New()
-
-	var obs observer.Table = &TableObserver{}
-	_ = obs.Values(&m.World)
+	var _ observer.Table = &TableObserver{}
 	// Output:
 }


### PR DESCRIPTION
* Observer interfaces `MatrixLayers` and `GridLayers` for multi-layered matrices and grids
* Observers `MatrixToLayers`, `GridToLayers` and `LayersToGrid` as adapters