### PR TITLE
Fix full CPU load when paused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [[v0.4.1]](https://github.com/mlange-42/arche-model/compare/v0.4.0...v0.4.1)
+
+### Bugfixes
+
+* Fixes `Systems` spinning at 100% CPU load despite low TPS and FPS (#47, see mlange-42/arche#304)
+
 ## [[v0.4.0]](https://github.com/mlange-42/arche-model/compare/v0.3.1...v0.4.0)
 
 ### Breaking changes

--- a/model/systems.go
+++ b/model/systems.go
@@ -247,7 +247,8 @@ func (s *Systems) updateSystems() bool {
 	if s.Paused {
 		update = !time.Now().Before(s.nextUpdate)
 		if update {
-			s.nextUpdate = nextTime(s.nextUpdate, 30)
+			tps := s.limitedFps(s.TPS, 10)
+			s.nextUpdate = nextTime(s.nextUpdate, tps)
 		}
 		return false
 	}
@@ -284,7 +285,7 @@ func (s *Systems) updateUISystems(updated bool) {
 			if !time.Now().Before(s.nextDraw) {
 				fps := s.FPS
 				if s.Paused {
-					fps = 30
+					fps = s.limitedFps(s.FPS, 30)
 				}
 				s.nextDraw = nextTime(s.nextDraw, fps)
 				for _, sys := range s.uiSystems {
@@ -340,4 +341,12 @@ func (s *Systems) reset() {
 
 	s.initialized = false
 	s.tickRes = generic.Resource[resource.Tick]{}
+}
+
+// Calculates frame rate capped to target
+func (s *Systems) limitedFps(actual, target float64) float64 {
+	if actual > target || actual <= 0 {
+		return target
+	}
+	return actual
 }

--- a/model/systems.go
+++ b/model/systems.go
@@ -271,29 +271,27 @@ func (s *Systems) updateSystems() bool {
 
 // Update UI systems.
 func (s *Systems) updateUISystems(updated bool) {
-	if len(s.uiSystems) > 0 {
-		if !s.Paused && s.FPS <= 0 {
-			if updated {
-				for _, sys := range s.uiSystems {
-					sys.UpdateUI(s.world)
-				}
-				for _, sys := range s.uiSystems {
-					sys.PostUpdateUI(s.world)
-				}
+	if !s.Paused && s.FPS <= 0 {
+		if updated {
+			for _, sys := range s.uiSystems {
+				sys.UpdateUI(s.world)
 			}
-		} else {
-			if !time.Now().Before(s.nextDraw) {
-				fps := s.FPS
-				if s.Paused {
-					fps = s.limitedFps(s.FPS, 30)
-				}
-				s.nextDraw = nextTime(s.nextDraw, fps)
-				for _, sys := range s.uiSystems {
-					sys.UpdateUI(s.world)
-				}
-				for _, sys := range s.uiSystems {
-					sys.PostUpdateUI(s.world)
-				}
+			for _, sys := range s.uiSystems {
+				sys.PostUpdateUI(s.world)
+			}
+		}
+	} else {
+		if !time.Now().Before(s.nextDraw) {
+			fps := s.FPS
+			if s.Paused {
+				fps = s.limitedFps(s.FPS, 30)
+			}
+			s.nextDraw = nextTime(s.nextDraw, fps)
+			for _, sys := range s.uiSystems {
+				sys.UpdateUI(s.world)
+			}
+			for _, sys := range s.uiSystems {
+				sys.PostUpdateUI(s.world)
 			}
 		}
 	}

--- a/model/systems.go
+++ b/model/systems.go
@@ -243,10 +243,14 @@ func (s *Systems) wait() {
 
 // Update normal systems.
 func (s *Systems) updateSystems() bool {
+	update := false
 	if s.Paused {
+		update = !time.Now().Before(s.nextUpdate)
+		if update {
+			s.nextUpdate = nextTime(s.nextUpdate, 30)
+		}
 		return false
 	}
-	update := false
 	if s.TPS <= 0 {
 		update = true
 		for _, sys := range s.systems {


### PR DESCRIPTION
As reported in mlange-42/arche#304, systems spin at maximum speed when paused.

This PR fixes the issue by calculating the theoretical next update time even when paused (assuming 30 TPS). Also, UI system update logic needs to be performed even when there are no UI systems.

Fixes mlange-42/arche#304