### PR TITLE
Add reporter.Callback, sensible zero UpdateInterval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## [[unpublished]](https://github.com/mlange-42/arche-model/compare/v0.7.0...main)
 
+### Features
+
+* Adds `reporter.Callback` for direct retrieval of observer output in Go code (#61)
+
 ### Bugfixes
 
 * Fix typo in error message when adding UI system as normal system (#60)
+* Fix reporters did not work with unspecified `UpdateInterval` (#61)
 
 ## [[v0.7.0]](https://github.com/mlange-42/arche-model/compare/v0.6.0...v0.7.0)
 

--- a/reporter/callback_test.go
+++ b/reporter/callback_test.go
@@ -20,6 +20,7 @@ func ExampleCallback() {
 		Callback: func(step int, row []float64) {
 			data = append(data, row)
 		},
+		HeaderCallback: func(header []string) {},
 	})
 
 	// Add a termination system that ends the simulation.

--- a/reporter/callback_test.go
+++ b/reporter/callback_test.go
@@ -1,0 +1,34 @@
+package reporter_test
+
+import (
+	"fmt"
+
+	"github.com/mlange-42/arche-model/model"
+	"github.com/mlange-42/arche-model/reporter"
+	"github.com/mlange-42/arche-model/system"
+)
+
+func ExampleCallback() {
+	// Create a new model.
+	m := model.New()
+
+	data := [][]float64{}
+
+	// Add a Print reporter with an Observer.
+	m.AddSystem(&reporter.Callback{
+		Observer: &ExampleObserver{},
+		Callback: func(step int, row []float64) {
+			data = append(data, row)
+		},
+	})
+
+	// Add a termination system that ends the simulation.
+	m.AddSystem(&system.FixedTermination{Steps: 3})
+
+	// Run the simulation.
+	m.Run()
+
+	fmt.Println(data)
+	// Output:
+	// [[1 2 3] [1 2 3] [1 2 3]]
+}

--- a/reporter/csv.go
+++ b/reporter/csv.go
@@ -28,6 +28,9 @@ type CSV struct {
 func (s *CSV) Initialize(w *ecs.World) {
 	s.Observer.Initialize(w)
 	s.header = s.Observer.Header()
+	if s.UpdateInterval == 0 {
+		s.UpdateInterval = 1
+	}
 	if s.Sep == "" {
 		s.Sep = ","
 	}

--- a/reporter/csv_example_test.go
+++ b/reporter/csv_example_test.go
@@ -13,10 +13,9 @@ func ExampleCSV() {
 
 	// Add a CSV reporter with an Observer.
 	m.AddSystem(&reporter.CSV{
-		Observer:       &ExampleObserver{},
-		File:           "../out/test.csv",
-		Sep:            ";",
-		UpdateInterval: 10,
+		Observer: &ExampleObserver{},
+		File:     "../out/test.csv",
+		Sep:      ";",
 	})
 
 	// Add a termination system that ends the simulation.

--- a/reporter/csv_snaphot.go
+++ b/reporter/csv_snaphot.go
@@ -27,6 +27,9 @@ type SnapshotCSV struct {
 func (s *SnapshotCSV) Initialize(w *ecs.World) {
 	s.Observer.Initialize(w)
 	s.header = s.Observer.Header()
+	if s.UpdateInterval == 0 {
+		s.UpdateInterval = 1
+	}
 
 	if s.Sep == "" {
 		s.Sep = ","

--- a/reporter/csv_snapshot_example_test.go
+++ b/reporter/csv_snapshot_example_test.go
@@ -13,10 +13,9 @@ func ExampleSnapshotCSV() {
 
 	// Add a SnapshotCSV reporter with an Observer.
 	m.AddSystem(&reporter.SnapshotCSV{
-		Observer:       &ExampleSnapshotObserver{},
-		FilePattern:    "../out/test-%06d.csv",
-		Sep:            ";",
-		UpdateInterval: 10,
+		Observer:    &ExampleSnapshotObserver{},
+		FilePattern: "../out/test-%06d.csv",
+		Sep:         ";",
 	})
 
 	// Add a termination system that ends the simulation.

--- a/reporter/csv_snapshot_test.go
+++ b/reporter/csv_snapshot_test.go
@@ -14,9 +14,8 @@ func TestSnapshotCSV(t *testing.T) {
 	m := model.New()
 
 	m.AddSystem(&reporter.SnapshotCSV{
-		Observer:       &ExampleSnapshotObserver{},
-		FilePattern:    "../out/test-%06d.csv",
-		UpdateInterval: 10,
+		Observer:    &ExampleSnapshotObserver{},
+		FilePattern: "../out/test-%06d.csv",
 	})
 	m.AddSystem(&system.FixedTermination{Steps: 100})
 

--- a/reporter/csv_test.go
+++ b/reporter/csv_test.go
@@ -14,9 +14,8 @@ func TestCSV(t *testing.T) {
 	m := model.New()
 
 	m.AddSystem(&reporter.CSV{
-		Observer:       &ExampleObserver{},
-		File:           "../out/test.csv",
-		UpdateInterval: 10,
+		Observer: &ExampleObserver{},
+		File:     "../out/test.csv",
 	})
 	m.AddSystem(&system.FixedTermination{Steps: 100})
 

--- a/reporter/print_test.go
+++ b/reporter/print_test.go
@@ -12,16 +12,17 @@ func ExamplePrint() {
 
 	// Add a Print reporter with an Observer.
 	m.AddSystem(&reporter.Print{
-		Observer:       &ExampleObserver{},
-		UpdateInterval: 10,
+		Observer: &ExampleObserver{},
 	})
 
 	// Add a termination system that ends the simulation.
-	m.AddSystem(&system.FixedTermination{Steps: 20})
+	m.AddSystem(&system.FixedTermination{Steps: 3})
 
 	// Run the simulation.
 	m.Run()
 	// Output:
+	// [A B C]
+	// [1 2 3]
 	// [A B C]
 	// [1 2 3]
 	// [A B C]


### PR DESCRIPTION
* Adds `reporter.Callback` for direct retrieval of observer output in Go code
* Fix reporters did not work with unspecified `UpdateInterval`